### PR TITLE
Fixed bug that prevent to find the proxy settings in the wrong path

### DIFF
--- a/src/Login/CertificationCheck/CertificationCheck.php
+++ b/src/Login/CertificationCheck/CertificationCheck.php
@@ -290,7 +290,7 @@ class CertificationCheck
             ];
 
             // Set proxy
-            if ($proxy = $this->settings['nemid']['login']['proxy']) {
+            if ($proxy = $this->settings['login']['proxy']) {
                 $params['proxy'] = $proxy;
             }
 

--- a/src/Login/CertificationCheck/CertificationCheck.php
+++ b/src/Login/CertificationCheck/CertificationCheck.php
@@ -279,6 +279,7 @@ class CertificationCheck
 
         // Init guzzle client
         $client = new Client();
+        
         try {
             // Build params
             $params = [


### PR DESCRIPTION
According to the original configuration structure the "proxy" settings is located at "login → proxy", however the "checkOcsp" method is trying to find the proxy settings into "nemid → login → proxy".

Because the configuration is injected using the Config object no matter if the configuration is saved inside the "nemid" directory, because the configuration is absolubtely structured into the configuration file itself.