### PR TITLE
 Fixed bug that prevent to set the settings to Webservices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,86 @@
 /vendor/
 /testcertificates/
 !/testcertificates/.gitkeep
+
+### macOS template
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+cmake-build-release/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+

--- a/src/Webservice/Settings.php
+++ b/src/Webservice/Settings.php
@@ -2,6 +2,8 @@
 
 namespace Nodes\NemId\PidCprMatch;
 
+use Nodes\NemId\Core\Mode;
+
 /**
  * Class Settings.
  *
@@ -49,6 +51,11 @@ class Settings
      */
     public function __construct(array $settings, $mode = null)
     {
+        // Fallback to default mode
+        if (!$mode || !($mode instanceof Mode)) {
+            $mode = new Mode();
+        }
+
         // Retrieve settings
         $this->settings = $settings;
 


### PR DESCRIPTION
The "Mode" object is not instantiated into the Webservices settings, so method "$mode->isFromSettings()" is never call it raising the following Warning:

`Warning: Uncaught Error: Call to a member function isFromSettings() on null `

The default configuration is always set to "Test" mode due this bug.