### PR TITLE
Fixing the timestamp field inside the parameters JSON object

### DIFF
--- a/src/Login/Login.php
+++ b/src/Login/Login.php
@@ -28,7 +28,7 @@ class Login
     public function __construct(array $settings, $mode = null)
     {
         $this->settings = new Settings($settings, $mode);
-        $this->timeStamp = (int) round(microtime(true) * 1000);
+        $this->timeStamp = (string) round(microtime(true) * 1000);
 
         $this->generateIFrameUrl();
         $this->generateParams();


### PR DESCRIPTION
The "timestamp" field seems to need to be a string inside the "parameters" JSON object for the NemID client to accept it.

The current version "fixes" this by doing a @foreach loop at the top of inspiration/applet.blade.php, but for everyone not using that, this change fixes the "parameters" JSON object.

The file inspiration/applet.blade.php and similar existing implementations _should_ still work without needing changes.

I believe this is the problem that @Valoneria and @daliborgogic encountered in issue #26.