### PR TITLE
PSR-4 namespace fix, minor XML fix and support for setting language

### DIFF
--- a/config/nemid.php
+++ b/config/nemid.php
@@ -23,6 +23,7 @@ return [
             'privateKeyPassword'  => '', // Password for the private key
             'privateKeyLocation'  => 'privateKey.pem', // Location for private key
             'certificateLocation' => 'publicCert.pem', // Location for public certificate
+            'language'            => 'da', // Supported languages: da (Danish, default), en (English), kl (Greenlandic)
         ],
         'testSettings' => [
             'baseUrl'             => 'https://appletk.danid.dk/', // Official url for testing environment
@@ -32,6 +33,7 @@ return [
             'privateKeyPassword'  => '', // Password for the private key
             'privateKeyLocation'  => 'testPrivateKey.pem', // Location for private key
             'certificateLocation' => 'testPublicCert.pem', // Location for public certificate
+            'language'            => 'da', // Supported languages: da (Danish, default), en (English), kl (Greenlandic)            
         ],
 
         // Check for certificate matching after login

--- a/config/nemid.php
+++ b/config/nemid.php
@@ -33,7 +33,7 @@ return [
             'privateKeyPassword'  => '', // Password for the private key
             'privateKeyLocation'  => 'testPrivateKey.pem', // Location for private key
             'certificateLocation' => 'testPublicCert.pem', // Location for public certificate
-            'language'            => 'da', // Supported languages: da (Danish, default), en (English), kl (Greenlandic)            
+            'language'            => 'da', // Supported languages: da (Danish, default), en (English), kl (Greenlandic)
         ],
 
         // Check for certificate matching after login
@@ -41,7 +41,6 @@ return [
         ],
         'checkOcsp' => true, // The certificate can be validated through a external request
         'proxy'     => false, // Since you only have 10 ip whitelisted, it can be smart to proxy the ip calls
-
     ],
     /*
     |--------------------------------------------------------------------------

--- a/src/Login/CertificationCheck/CertificationCheck.php
+++ b/src/Login/CertificationCheck/CertificationCheck.php
@@ -43,7 +43,9 @@ class CertificationCheck
      */
     public static function isXml(string $xml)
     {
-        if ($xml[0] !== '<') return false;
+        if ($xml[0] !== '<') {
+            return false;
+        }
 
         try {
             $document = new \DOMDocument();

--- a/src/Login/CertificationCheck/CertificationCheck.php
+++ b/src/Login/CertificationCheck/CertificationCheck.php
@@ -41,8 +41,10 @@ class CertificationCheck
      *
      * @return bool
      */
-    public static function isXml($xml)
+    public static function isXml(string $xml)
     {
+        if ($xml[0] !== '<') return false;
+
         try {
             $document = new \DOMDocument();
             $document->loadXML($xml);

--- a/src/Login/CertificationCheck/CertificationCheck.php
+++ b/src/Login/CertificationCheck/CertificationCheck.php
@@ -43,15 +43,11 @@ class CertificationCheck
      */
     public static function isXml(string $xml)
     {
-        if ($xml[0] !== '<') {
-            return false;
-        }
-
         try {
             $document = new \DOMDocument();
-            $document->loadXML($xml);
+            $result = $document->loadXML($xml, LIBXML_NOWARNING | LIBXML_NOERROR);
 
-            return true;
+            return (bool) $result;
         } catch (\Exception $e) {
             return false;
         }

--- a/src/Login/Login.php
+++ b/src/Login/Login.php
@@ -61,6 +61,7 @@ class Login
             'SP_CERT'    => $certificate,
             'CLIENTFLOW' => 'Oceslogin2',
             'TIMESTAMP'  => $this->timeStamp,
+            'LANGUAGE'   => $this->settings->getLanguage(),
         ];
 
         // Add origin if set
@@ -140,5 +141,16 @@ class Login
     public function getSettings()
     {
         return $this->settings;
+    }
+
+    /**
+     * @author Tim Johannessen <twj@smbsolutions.dk>
+     *
+     * @param string $language
+     */
+    public function setLanguage(string $language)
+    {
+        $this->settings->setLanguage($language);
+        $this->generateParams();
     }
 }

--- a/src/Login/Login.php
+++ b/src/Login/Login.php
@@ -53,8 +53,11 @@ class Login
     private function generateParams()
     {
         // Trim certificate
-        $certificate = preg_replace('/(-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----|\s)/s', '',
-            $this->settings->getCertificate());
+        $certificate = preg_replace(
+            '/(-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----|\s)/s',
+            '',
+            $this->settings->getCertificate()
+        );
 
         // Init start params
         $params = [

--- a/src/Login/Settings.php
+++ b/src/Login/Settings.php
@@ -24,6 +24,7 @@ class Settings
     protected $privateKey;
     protected $privateKeyPassword;
     protected $certificate;
+    protected $language;
 
     /**
      * var boolean.
@@ -80,6 +81,7 @@ class Settings
         $this->privateKeyPassword = $settings['privateKeyPassword'];
         $this->privateKey = file_get_contents($settings['privateKeyLocation']);
         $this->certificate = file_get_contents($settings['certificateLocation']);
+        $this->language = $settings['language'];
     }
 
     /**
@@ -170,5 +172,25 @@ class Settings
     public function showCancelBtn()
     {
         return $this->showCancelBtn;
+    }
+
+    /**
+     * @author Tim Johannessen <twj@smbsolutions.dk>
+     *
+     * @return string
+     */
+    public function getLanguage()
+    {
+        return $this->language;
+    }
+
+    /**
+     * @author Tim Johannessen <twj@smbsolutions.dk>
+     *
+     * @param string $language
+     */
+    public function setLanguage(string $language)
+    {
+        $this->language = $language;
     }
 }

--- a/src/Login/Settings.php
+++ b/src/Login/Settings.php
@@ -81,7 +81,7 @@ class Settings
         $this->privateKeyPassword = $settings['privateKeyPassword'];
         $this->privateKey = file_get_contents($settings['privateKeyLocation']);
         $this->certificate = file_get_contents($settings['certificateLocation']);
-        $this->language = $settings['language'];
+        $this->language = $settings['language'] ?: 'da';
     }
 
     /**

--- a/src/Webservice/PidCprMatch/PidCprMatch.php
+++ b/src/Webservice/PidCprMatch/PidCprMatch.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace Nodes\NemId\PidCprMatch;
+namespace Nodes\NemId\Webservice\PidCprMatch;
 
 use GuzzleHttp\Client;
-use Nodes\NemId\PidCprMatch\Responses\Response;
+use Nodes\NemId\Webservice\PidCprMatch\Responses\Response;
+use Nodes\NemId\Webservice\Settings;
 
 /**
  * Class PidCprMatch.

--- a/src/Webservice/PidCprMatch/Responses/Response.php
+++ b/src/Webservice/PidCprMatch/Responses/Response.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nodes\NemId\PidCprMatch\Responses;
+namespace Nodes\NemId\Webservice\PidCprMatch\Responses;
 
 /**
  * Class Response.

--- a/src/Webservice/Settings.php
+++ b/src/Webservice/Settings.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nodes\NemId\PidCprMatch;
+namespace Nodes\NemId\Webservice;
 
 use Nodes\NemId\Core\Mode;
 


### PR DESCRIPTION
Corrected the namespace and added a small fix to avoid a DomXML warning it attempting to load a non-XML response such as a NemID error code.