### PR TITLE
Fix OCSP check

### DIFF
--- a/src/Login/CertificationCheck/CertificationCheck.php
+++ b/src/Login/CertificationCheck/CertificationCheck.php
@@ -284,7 +284,7 @@ class CertificationCheck
             // Build params
             $params = [
                 'headers'         => [
-                    'Content-type: application/ocsp-request'."\r\n",
+                    'Content-type: application/ocsp-request',
                 ],
                 'body'            => $ocsPreq,
                 'connect_timeout' => 10,


### PR DESCRIPTION
It was throwing "Failed to check certificate: cURL error 56: Recv failure: Connection reset by peer (see https://curl.haxx.se/libcurl/c/libcurl-errors.html)".

The extra characters are most likely legacy of the old codebase. See original line here: https://github.com/tobandan/nemid-php/blob/master/lib/Nemid.php#L218